### PR TITLE
Feature/adjust definitions structure

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -74,7 +74,8 @@ export default {
           useMaximumLength: false
         }
       },
-      slots: []
+      slots: [],
+      conceptAssociations: []
     }
   },
   defaultGroup () {

--- a/assets/js/data-element.js
+++ b/assets/js/data-element.js
@@ -17,7 +17,8 @@ export default {
       slots: [],
       valueDomain: {
         type: 'STRING'
-      }
+      },
+      concepts: []
     }
   },
   defaultTextValidation () {

--- a/components/common/alert-icon.vue
+++ b/components/common/alert-icon.vue
@@ -1,0 +1,33 @@
+<template v-slot:item.action="{ item }">
+  <v-hover v-slot="{ hover }">
+    <v-badge
+      :value="hover"
+      color="#0000"
+      left
+      transition="slide-x-transition"
+    >
+      <span slot="badge">
+        <v-card>
+          <v-list>
+            <v-list-item-title dark>{{ title }}</v-list-item-title>
+            <v-list-item
+              v-for="(item, i) in alerts"
+              :key="i"
+            >
+              <v-list-item-subtitle>{{ '- ' + item }}</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </span>
+      <v-icon>mdi-alert-circle</v-icon>
+    </v-badge>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    title: { required: false, default: '', type: String },
+    alerts: { required: true, type: Array }
+  }
+}
+</script>

--- a/components/common/members.vue
+++ b/components/common/members.vue
@@ -146,8 +146,8 @@ export default {
             members.push({
               id,
               elementType: member.elementType,
-              designation: member.definition.designation,
-              definition: member.definition.definition,
+              designation: member.definitions[0].designation,
+              definition: member.definitions[0].definition,
               status: member.status
             })
           }
@@ -164,8 +164,8 @@ export default {
             members.push({
               id: member.urn,
               elementType,
-              designation: member.definition.designation,
-              definition: member.definition.definition
+              designation: member.definitions[0].designation,
+              definition: member.definitions[0].definition
             })
           }
           this.selectedMembers = members

--- a/components/dialogs/data-element-dialog.vue
+++ b/components/dialogs/data-element-dialog.vue
@@ -165,6 +165,54 @@
               </v-row>
             </v-list-item>
           </v-list>
+          <v-list subheader>
+            <v-subheader>{{ $t('global.conceptAssociations') }}</v-subheader>
+            <v-list-item>
+              <v-list-item-action>
+                <v-btn
+                  color="primary"
+                  rounded
+                  small
+                  @click="addConceptAssociation"
+                >
+                  <v-icon dark>
+                    mdi-plus
+                  </v-icon>
+                  {{ $t('global.button.add') }}
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+            <v-list-item
+              v-for="(concept, index) in dataElement.conceptAssociations"
+              :key="index"
+            >
+              <v-row>
+                <v-col cols="11">
+                  <item-concept-association
+                    :concept-association="concept"
+                    @conceptChanged="concept = $event"
+                  />
+                </v-col>
+                <v-col cols="1">
+                  <v-list-item>
+                    <v-list-item-action>
+                      <v-btn
+                        color="secondary"
+                        rounded
+                        small
+                        @click="deleteConceptAssociation(index)"
+                      >
+                        <v-icon dark>
+                          mdi-delete
+                        </v-icon>
+                        {{ $t('global.button.delete') }}
+                      </v-btn>
+                    </v-list-item-action>
+                  </v-list-item>
+                </v-col>
+              </v-row>
+            </v-list-item>
+          </v-list>
           <template v-if="!released && !edit">
             <v-list subheader>
               <v-subheader>{{ $t('global.valueDomain') }}</v-subheader>
@@ -263,6 +311,7 @@
 import Ajax from '~/config/ajax'
 import Common from '~/assets/js/common'
 import ItemDefinition from '~/components/item/item-definition'
+import ItemConceptAssociation from '~/components/item/item-concept-association'
 import ItemSlot from '~/components/item/item-slot'
 import DataElement from '~/assets/js/data-element'
 import TextValidation from '~/components/validation/text'
@@ -275,6 +324,7 @@ export default {
     ItemSlot,
     TextValidation,
     NumericValidation,
+    ItemConceptAssociation,
     PermittedValuesValidation,
     DatetimeValidation
   },
@@ -389,14 +439,8 @@ export default {
           await this.$axios.post(this.ajax.dataElementUrl,
             this.dataElement)
             .then(function (res) {
-              this.$axios.$get(res.headers.location)
-                .then(function (res1) {
-                  this.dataElement.identification.urn = res1.identification.urn
-                  this.dataElement.parentUrn = ''
-                  this.dataElement.action = 'CREATE'
-                  this.$emit('save', this.dataElement)
-                  this.hideDialog()
-                }.bind(this))
+              this.hideDialog()
+              this.$emit('save', this.dataElement)
             }.bind(this))
             .catch(function (err) {
               this.$log.debug('Could not save DataElement: ' + err)
@@ -407,14 +451,9 @@ export default {
           await this.$axios.put(this.ajax.dataElementUrl + this.dataElement.identification.urn,
             this.dataElement)
             .then(function (res) {
-              this.$axios.$get(res.headers.location)
-                .then(function (res1) {
-                  this.dataElement.identification.urn = res1.identification.urn
-                  this.dataElement.previousUrn = this.urn
-                  this.dataElement.action = 'UPDATE'
-                  this.$emit('save', this.dataElement)
-                  this.hideDialog()
-                }.bind(this))
+              this.hideDialog()
+              this.$log.debug(this.dataElement)
+              this.$emit('save', this.dataElement)
             }.bind(this))
             .catch(function (err) {
               this.$log.debug('Could not save DataElement: ' + err)
@@ -428,6 +467,12 @@ export default {
     },
     deleteDefinition (index) {
       this.dataElement.definitions.splice(index, 1)
+    },
+    addConceptAssociation () {
+      this.dataElement.conceptAssociations.push(ItemConceptAssociation.data().defaultConcept)
+    },
+    deleteConceptAssociation (index) {
+      this.dataElement.conceptAssociations.splice(index, 1)
     },
     addSlot () {
       this.dataElement.slots.push({ name: '', value: '', language: 'en' })

--- a/components/dialogs/data-element-dialog.vue
+++ b/components/dialogs/data-element-dialog.vue
@@ -47,7 +47,7 @@
                   :items="namespaces"
                   :rules="selectNamespaceRules"
                   item-value="identification.urn"
-                  item-text="definition.designation"
+                  item-text="definitions[0].designation"
                   :label="$t('global.select.namespace')"
                 />
               </v-list-item-action>

--- a/components/dialogs/group-record-dialog.vue
+++ b/components/dialogs/group-record-dialog.vue
@@ -47,7 +47,7 @@
                   :items="namespaces"
                   :rules="selectNamespaceRules"
                   item-value="identification.urn"
-                  item-text="definition.designation"
+                  item-text="definitions[0].designation"
                   :label="$t('global.select.namespace')"
                 />
               </v-list-item-action>

--- a/components/item/item-concept-association.vue
+++ b/components/item/item-concept-association.vue
@@ -1,0 +1,119 @@
+<template>
+  <div>
+    <v-row>
+      <v-col cols="4">
+        <v-text-field
+          v-model="currentConcept.system"
+          :counter="255"
+          :rules="rules"
+          :label="label[0]"
+          required
+        />
+      </v-col>
+      <v-col cols="4">
+        <v-text-field
+          v-model="currentConcept.version"
+          :counter="255"
+          :rules="rules"
+          :label="label[1]"
+          required
+        />
+      </v-col>
+      <v-col cols="4">
+        <v-text-field
+          v-model="currentConcept.term"
+          :counter="255"
+          :rules="rules"
+          :label="label[2]"
+          required
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <v-text-field
+          v-model="currentConcept.text"
+          :counter="65000"
+          :rules="rules"
+          :label="label[3]"
+          required
+        />
+      </v-col>
+      <v-col cols="4">
+        <v-select
+          v-model="currentConcept.linktype"
+          :items="linkTypes"
+          :label="label[4]"
+          required
+        />
+      </v-col>
+    </v-row>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    conceptAssociation: { required: false, default: () => this.defaultConcept, type: Object }
+  },
+  data () {
+    return {
+      ajax: {
+        sourceIdUrl: process.env.mdrBackendUrl + '/v1/source/'
+      },
+      sourceIds: [],
+      currentConcept: this.conceptAssociation,
+      defaultConcept: {
+        system: '',
+        version: '',
+        term: '',
+        text: '',
+        linktype: 'undefined'
+      },
+      linkTypes: [
+        'undefined',
+        'equal',
+        'equivalent',
+        'wider',
+        'subsumes',
+        'narrower',
+        'specializes',
+        'inexact'
+      ]
+    }
+  },
+  computed: {
+    rules () {
+      return [
+        v => !!v || this.$t('global.form.validation.messages.requiredField')
+      ]
+    },
+    label () {
+      return [
+        this.$t('global.system'),
+        this.$t('global.version'),
+        this.$t('global.term'),
+        this.$t('global.text'),
+        this.$t('global.linkType')
+      ]
+    }
+  },
+  watch: {
+    currentConcept () {
+      this.$emit('conceptChanged', this.currentConcept)
+    }
+  },
+  mounted () {
+    this.getSourceId()
+  },
+  methods: {
+    async getSourceId () {
+      await this.$axios.$get(this.ajax.sourceIdUrl)
+        .then(function (res) {
+          this.sourceIds = res
+          this.currentConcept.sourceId = this.sourceIds.find(elem => elem.type ===
+          'DATAELEMENTHUB').id
+        }.bind(this))
+    }
+  }
+}
+</script>

--- a/components/item/item-definition.vue
+++ b/components/item/item-definition.vue
@@ -46,7 +46,29 @@ export default {
       },
       languageItems: [
         'en',
-        'de'
+        'bg',
+        'es',
+        'cz',
+        'da',
+        'de',
+        'et',
+        'el',
+        'fr',
+        'ga',
+        'hr',
+        'it',
+        'lv',
+        'lt',
+        'hu',
+        'mt',
+        'nl',
+        'pl',
+        'pt',
+        'ro',
+        'sk',
+        'sl',
+        'fi',
+        'sv'
       ]
     }
   },

--- a/components/tables/concept-association-table.vue
+++ b/components/tables/concept-association-table.vue
@@ -34,7 +34,7 @@ export default {
           {
             text: this.$i18n.t('global.linkType'),
             sortable: false,
-            value: 'linkType'
+            value: 'linktype'
           },
           {
             text: this.$i18n.t('global.version'),

--- a/components/trees/namespace-tree.vue
+++ b/components/trees/namespace-tree.vue
@@ -72,7 +72,7 @@ export default {
           for (const namespace of Array.from(res.ADMIN.concat(res.READ, res.WRITE))) {
             this.treeItems.push({
               id: namespace.identification.identifier,
-              name: namespace.definition.designation,
+              name: namespace.definitions[0].designation,
               elementType: 'NAMESPACE',
               children: []
             })
@@ -100,7 +100,7 @@ export default {
             }
             members.push({
               id,
-              name: member.definition.designation,
+              name: member.definitions[0].designation,
               elementType,
               children: elementType === 'DATAELEMENT' ? undefined : []
             })

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -95,8 +95,6 @@ export default {
     date: 'Date',
     time: 'Time',
     hourFormat: 'Hour Format',
-    frontend: 'Frontend',
-    backend: 'Backend',
     address: {
       name1: 'Universitätsklinikum Frankfurt',
       name2: 'Medical Informatics Group (MIG)',
@@ -134,6 +132,7 @@ export default {
     form: {
       validation: {
         messages: {
+          requiredField: 'This Field is required',
           definitionRequired: 'Definition is required',
           designationRequired: 'Designation is required',
           languageRequired: 'Language is required',
@@ -172,11 +171,13 @@ export default {
       title: 'Home',
       subtitle: '',
       content: {
-        howdy: 'Welcome to DataelementHub (DEHub)!',
-        preAlpha: 'What you see here is a Alpha Version of the new DataElement Hub GUI. So do not expect a fully working bug-free Version. We are continuously working on improving the software.',
-        bugReport: 'When you come across a bug, feel free to create an Issue in the projects repository, which can be found here (<a href="https://github.com/mig-frankfurt/dataelementhub.gui" target="_blank">https://github.com/mig-frankfurt/dataelementhub.gui</a>) .',
+        howdy: 'Howdy stranger!',
+        preAlpha: 'What you see here is a <b>PreAlpha</b> Version of the new DataElement Hub GUI. ' +
+          'So do not expect a fully working bug-free Version. Quite the contrary, expect the worst.',
+        bugReport: 'If you stumble over a bug, feel free to create an Issue in the projects repository, which can be found ' +
+          '<a href="https://github.com/mig-frankfurt/dataelementhub.gui" target="_blank">here</a>.',
         dockerImage: 'From time to time there will be new a new Release of the corresponding Docker image. So be sure to check that too.',
-        thanks: 'For further information please visit <a href="https://dataelementhub.de" target="_blank">https://dataelementhub.de</a><br><br><b>Thanks!</b>'
+        thanks: '<b>Thanks!</b>'
       }
     },
     namespaces: {
@@ -320,11 +321,11 @@ export default {
       subtitle: ''
     },
     about: {
-      title: 'About the DataElementHub',
+      title: 'About the DataElement Hub',
       subtitle: ''
     },
     help: {
-      title: 'Help',
+      title: 'Help?',
       subtitle: ''
     },
     login: {

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -33,6 +33,10 @@ export default {
       about: 'About',
       help: 'Help'
     },
+    alerts: {
+      warning: 'WARNING!',
+      defineLanguage: 'Preferred Language is not defined.'
+    },
     button: {
       save: 'Save',
       cancel: 'Cancel',

--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -323,7 +323,7 @@ export default {
               members.push({
                 id,
                 editable: this.getNamespace(id).editable,
-                isPreferredLanguage: this.preferredLanguage.includes(member.definitions[0].language),
+                isPreferredLanguage: this.ajax.preferredLanguage.includes(member.definitions[0].language),
                 name: member.definitions[0].designation,
                 elementType,
                 children: elementType === 'DATAELEMENT' ? undefined : []

--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -89,6 +89,11 @@
             </v-icon>
           </template>
           <template #append="{ item }">
+            <AlertIcon
+              v-if="!item.isPreferredLanguage"
+              :title="$t('global.alerts.warning')"
+              :alerts="[$t('global.alerts.defineLanguage')]"
+            />
             <v-menu
               bottom
               offset-y
@@ -165,6 +170,7 @@
 
 <script>
 import Ajax from '~/config/ajax'
+import AlertIcon from '~/components/common/alert-icon'
 import NamespaceDialog from '~/components/dialogs/namespace-dialog'
 import DataElementDialog from '~/components/dialogs/data-element-dialog'
 import GroupRecordDialog from '~/components/dialogs/group-record-dialog'
@@ -174,6 +180,7 @@ import NamespaceDetailView from '~/components/views/namespace-detail-view.vue'
 import DefaultSnackbar from '~/components/snackbars/default-snackbar'
 export default {
   components: {
+    AlertIcon,
     NamespaceDialog,
     DataElementDialog,
     GroupRecordDialog,
@@ -186,7 +193,8 @@ export default {
     componentKey: 0,
     ajax: {
       namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/',
-      elementUrl: process.env.mdrBackendUrl + '/v1/element/'
+      elementUrl: process.env.mdrBackendUrl + '/v1/element/',
+      preferredLanguage: 'de,en-US;q=0.7,en;q=0.3'
     },
     dialog: {
       urn: '',
@@ -281,6 +289,7 @@ export default {
               this.treeItems.push({
                 id: namespace.identification.urn,
                 editable: !res.READ.includes(namespace),
+                isPreferredLanguage: this.ajax.preferredLanguage.includes(namespace.definitions[0].language),
                 name: namespace.definitions[0].designation,
                 elementType: 'NAMESPACE',
                 children: []
@@ -314,6 +323,7 @@ export default {
               members.push({
                 id,
                 editable: this.getNamespace(id).editable,
+                isPreferredLanguage: this.preferredLanguage.includes(member.definitions[0].language),
                 name: member.definitions[0].designation,
                 elementType,
                 children: elementType === 'DATAELEMENT' ? undefined : []

--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -281,7 +281,7 @@ export default {
               this.treeItems.push({
                 id: namespace.identification.urn,
                 editable: !res.READ.includes(namespace),
-                name: namespace.definition.designation,
+                name: namespace.definitions[0].designation,
                 elementType: 'NAMESPACE',
                 children: []
               })
@@ -314,7 +314,7 @@ export default {
               members.push({
                 id,
                 editable: this.getNamespace(id).editable,
-                name: member.definition.designation,
+                name: member.definitions[0].designation,
                 elementType,
                 children: elementType === 'DATAELEMENT' ? undefined : []
               })


### PR DESCRIPTION
**What's in the PR**
* GUI should only accept defintions as list of objects and not only defintion as an object
* Show Alert icon if preferred definition language is not available

**How to test manually**
* GUI should work properly after sending defintions as list of objects from backend
*  Alert icon should be shown in treeView if an element does not contain a defintion with preferred language
