### PR TITLE
#11 - Adjust definitions structure

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -13,6 +13,9 @@ export default {
       return null
     }
   },
+  preferredLanguage () {
+    return 'de,en-US;q=0.7,en;q=0.3'
+  },
   // Return all element types
   elementTypes () {
     return [

--- a/components/common/alert-icon.vue
+++ b/components/common/alert-icon.vue
@@ -1,0 +1,33 @@
+<template v-slot:item.action="{ item }">
+  <v-hover v-slot="{ hover }">
+    <v-badge
+      :value="hover"
+      color="#0000"
+      left
+      transition="slide-x-transition"
+    >
+      <span slot="badge">
+        <v-card>
+          <v-list>
+            <v-list-item-title dark>{{ title }}</v-list-item-title>
+            <v-list-item
+              v-for="(item, i) in alerts"
+              :key="i"
+            >
+              <v-list-item-subtitle>{{ '- ' + item }}</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </span>
+      <v-icon>mdi-alert-circle</v-icon>
+    </v-badge>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    title: { required: false, default: '', type: String },
+    alerts: { required: true, type: Array }
+  }
+}
+</script>

--- a/components/common/members.vue
+++ b/components/common/members.vue
@@ -146,8 +146,8 @@ export default {
             members.push({
               id,
               elementType: member.elementType,
-              designation: member.definition.designation,
-              definition: member.definition.definition,
+              designation: member.definitions[0].designation,
+              definition: member.definitions[0].definition,
               status: member.status
             })
           }
@@ -164,8 +164,8 @@ export default {
             members.push({
               id: member.urn,
               elementType,
-              designation: member.definition.designation,
-              definition: member.definition.definition
+              designation: member.definitions[0].designation,
+              definition: member.definitions[0].definition
             })
           }
           this.selectedMembers = members

--- a/components/dialogs/data-element-dialog.vue
+++ b/components/dialogs/data-element-dialog.vue
@@ -47,7 +47,7 @@
                   :items="namespaces"
                   :rules="selectNamespaceRules"
                   item-value="identification.urn"
-                  item-text="definition.designation"
+                  item-text="definitions[0].designation"
                   :label="$t('global.select.namespace')"
                 />
               </v-list-item-action>

--- a/components/dialogs/group-record-dialog.vue
+++ b/components/dialogs/group-record-dialog.vue
@@ -47,7 +47,7 @@
                   :items="namespaces"
                   :rules="selectNamespaceRules"
                   item-value="identification.urn"
-                  item-text="definition.designation"
+                  item-text="definitions[0].designation"
                   :label="$t('global.select.namespace')"
                 />
               </v-list-item-action>
@@ -297,6 +297,7 @@ export default {
         : Common.defaultGroup()
     },
     hideDialog () {
+      this.clearForm()
       this.dialog = false
       this.$emit('dialogClosed')
     },
@@ -372,6 +373,13 @@ export default {
     },
     deleteSlot (index) {
       this.element.slots.splice(index, 1)
+    },
+    clearForm () {
+      this.element.definitions = [
+        ItemDefinition.data().defaultDefinition
+      ]
+      this.element.slots = []
+      this.element.members = []
     }
   }
 }

--- a/components/item/item-definition.vue
+++ b/components/item/item-definition.vue
@@ -46,7 +46,30 @@ export default {
       },
       languageItems: [
         'en',
-        'de'
+        'de',
+        'bg',
+        'es',
+        'cz',
+        'da',
+        'de',
+        'et',
+        'el',
+        'fr',
+        'ga',
+        'hr',
+        'it',
+        'lv',
+        'lt',
+        'hu',
+        'mt',
+        'nl',
+        'pl',
+        'pt',
+        'ro',
+        'sk',
+        'sl',
+        'fi',
+        'sv'
       ]
     }
   },

--- a/components/trees/namespace-tree.vue
+++ b/components/trees/namespace-tree.vue
@@ -72,7 +72,7 @@ export default {
           for (const namespace of Array.from(res.ADMIN.concat(res.READ, res.WRITE))) {
             this.treeItems.push({
               id: namespace.identification.identifier,
-              name: namespace.definition.designation,
+              name: namespace.definitions[0].designation,
               elementType: 'NAMESPACE',
               children: []
             })
@@ -100,7 +100,7 @@ export default {
             }
             members.push({
               id,
-              name: member.definition.designation,
+              name: member.definitions[0].designation,
               elementType,
               children: elementType === 'DATAELEMENT' ? undefined : []
             })

--- a/config/ajax.js
+++ b/config/ajax.js
@@ -1,4 +1,5 @@
 export default {
+  preferredLanguage: 'de,en-US;q=0.7,en;q=0.3',
   header: {
     listView: { headers: { Accept: 'application/vnd+de.dataelementhub.listview+json' } },
     updateItem: { headers: { 'Accept-Language': '' } },

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -33,6 +33,10 @@ export default {
       about: 'About',
       help: 'Help'
     },
+    alerts: {
+      warning: 'WARNING!',
+      defineLanguage: 'Preferred Language is not defined.'
+    },
     button: {
       save: 'Save',
       cancel: 'Cancel',

--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -89,6 +89,11 @@
             </v-icon>
           </template>
           <template #append="{ item }">
+            <AlertIcon
+              v-if="!item.isPreferredLanguage"
+              :title="$t('global.alerts.warning')"
+              :alerts="[$t('global.alerts.defineLanguage')]"
+            />
             <v-menu
               bottom
               offset-y
@@ -165,6 +170,7 @@
 
 <script>
 import Ajax from '~/config/ajax'
+import AlertIcon from '~/components/common/alert-icon'
 import NamespaceDialog from '~/components/dialogs/namespace-dialog'
 import DataElementDialog from '~/components/dialogs/data-element-dialog'
 import GroupRecordDialog from '~/components/dialogs/group-record-dialog'
@@ -174,6 +180,7 @@ import NamespaceDetailView from '~/components/views/namespace-detail-view.vue'
 import DefaultSnackbar from '~/components/snackbars/default-snackbar'
 export default {
   components: {
+    AlertIcon,
     NamespaceDialog,
     DataElementDialog,
     GroupRecordDialog,
@@ -240,7 +247,8 @@ export default {
         editable: true,
         name: element.definitions[0].designation,
         elementType: element.identification.elementType,
-        children: element.identification.elementType === 'DATAELEMENT' ? undefined : []
+        children: element.identification.elementType === 'DATAELEMENT' ? undefined : [],
+        isPreferredLanguage: Ajax.preferredLanguage.includes(element.definitions[0].language)
       }
       switch (element.identification.elementType) {
         case 'NAMESPACE': {
@@ -280,8 +288,9 @@ export default {
             if (namespace.identification.status !== 'OUTDATED') {
               this.treeItems.push({
                 id: namespace.identification.urn,
+                isPreferredLanguage: Ajax.preferredLanguage.includes(namespace.definitions[0].language),
                 editable: !res.READ.includes(namespace),
-                name: namespace.definition.designation,
+                name: namespace.definitions[0].designation,
                 elementType: 'NAMESPACE',
                 children: []
               })
@@ -314,7 +323,8 @@ export default {
               members.push({
                 id,
                 editable: this.getNamespace(id).editable,
-                name: member.definition.designation,
+                isPreferredLanguage: Ajax.preferredLanguage.includes(member.definitions[0].language),
+                name: member.definitions[0].designation,
                 elementType,
                 children: elementType === 'DATAELEMENT' ? undefined : []
               })
@@ -378,7 +388,7 @@ export default {
       return this.isNamespace(id)
         ? this.treeItems.find(elem => elem.id === id)
         : this.treeItems.find(elem => elem.id.split(':')[1] ===
-          namespaceIdentifier).id
+          namespaceIdentifier)
     }
   }
 }


### PR DESCRIPTION
**What's in the PR**
* GUI should only accept defintions as list of objects and not only defintion as an object
* Show Alert icon if preferred definition language is not available

**How to test manually**
* GUI should work properly after sending defintions as list of objects from backend
*  Alert icon should be shown in treeView if an element does not contain a defintion with preferred language
