### PR TITLE
#25 - Hide subElements in main view

### DIFF
--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -330,7 +330,7 @@ export default {
         ? this.ajax.elementUrl + element.urn +
         '/members'
         : this.ajax.namespaceUrl + element.urn.split(':')[3] +
-        '/members', Ajax.header.listView)
+        '/members?hideSubElements=true', Ajax.header.listView)
         .then(function (res) {
           const members = []
           for (const member of Array.from(res)) {


### PR DESCRIPTION
**What's in the PR**
* View grouped elements only in their groups.

**How to test manually**
* Create namespace, dataElementGroup and two dataElements
* Make one of the dataElements member of the dataElementGroup 
* The grouped dataElement will only be viewed in its dataElementGroup
