### PR TITLE
#27 - Navigation drawer is not displayed properly

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,6 +4,7 @@
       v-model="drawer"
       :mini-variant="miniVariant"
       :clipped="clipped"
+      permanent
       fixed
       app
     >
@@ -198,7 +199,7 @@ export default {
       clipped: false,
       drawer: false,
       fixed: false,
-      miniVariant: false,
+      miniVariant: true,
       right: true,
       rightDrawer: false,
       title: 'global.appName'


### PR DESCRIPTION
**What's in the PR**
* Navigation drawer will be displayed for all screen sizes.

**How to test manually**
* Use dehub gui with different screen sizes and the navigation drawer should keep showing.
