### PR TITLE
#56 - data element group members are not visible in the update dialog

### DIFF
--- a/components/common/members.vue
+++ b/components/common/members.vue
@@ -115,8 +115,10 @@ export default {
       handler () {
         if (this.search.query) {
           this.membersToChooseFrom = this.search.filteredMembers
+            .filter(ar => !this.selectedMembers.find(rm => rm.id.toUpperCase() === ar.id.toUpperCase()))
         } else {
           this.membersToChooseFrom = this.excludeSelectedMembers
+            .filter(ar => !this.selectedMembers.find(rm => rm.id.toUpperCase() === ar.id.toUpperCase()))
         }
       },
       deep: true,
@@ -125,8 +127,10 @@ export default {
     namespaceMembers () {
       if (this.search.query) {
         this.membersToChooseFrom = this.search.filteredMembers
+          .filter(ar => !this.selectedMembers.find(rm => rm.id.toUpperCase() === ar.id.toUpperCase()))
       } else {
         this.membersToChooseFrom = this.excludeSelectedMembers
+          .filter(ar => !this.selectedMembers.find(rm => rm.id.toUpperCase() === ar.id.toUpperCase()))
       }
     },
     selectedMembers () {
@@ -145,7 +149,9 @@ export default {
           for (const member of Array.from(res)) {
             const id = 'urn:' + namespaceIdentifier + ':' +
             member.elementType + ':' + member.identifier + ':' + member.revision
-            if (member.status.toUpperCase() !== 'OUTDATED' && id.toUpperCase() !== this.elementUrn.toUpperCase()) { // OUTDATED elements are not allowed to be added as members
+            if (member.status.toUpperCase() !== 'OUTDATED' && // OUTDATED elements are not allowed to be added as members
+              id.toUpperCase() !== this.elementUrn.toUpperCase()
+            ) {
               members.push({
                 id,
                 elementType: member.elementType,
@@ -169,7 +175,8 @@ export default {
               id: member.urn,
               elementType,
               designation: member.definitions[0].designation,
-              definition: member.definitions[0].definition
+              definition: member.definitions[0].definition,
+              status: member.status
             })
           }
           this.selectedMembers = members

--- a/components/common/members.vue
+++ b/components/common/members.vue
@@ -130,6 +130,8 @@ export default {
       }
     },
     selectedMembers () {
+      this.membersToChooseFrom = this.membersToChooseFrom
+        .filter(ar => !this.selectedMembers.find(rm => rm.id.toUpperCase() === ar.id.toUpperCase()))
       this.$emit('selectedMembers', this.selectedMembers)
     }
   },
@@ -143,13 +145,15 @@ export default {
           for (const member of Array.from(res)) {
             const id = 'urn:' + namespaceIdentifier + ':' +
             member.elementType + ':' + member.identifier + ':' + member.revision
-            members.push({
-              id,
-              elementType: member.elementType,
-              designation: member.definitions[0].designation,
-              definition: member.definitions[0].definition,
-              status: member.status
-            })
+            if (member.status.toUpperCase() !== 'OUTDATED' && id.toUpperCase() !== this.elementUrn.toUpperCase()) { // OUTDATED elements are not allowed to be added as members
+              members.push({
+                id,
+                elementType: member.elementType,
+                designation: member.definitions[0].designation,
+                definition: member.definitions[0].definition,
+                status: member.status
+              })
+            }
           }
           this.namespaceMembers = members
         }.bind(this))

--- a/components/dialogs/group-record-dialog.vue
+++ b/components/dialogs/group-record-dialog.vue
@@ -167,6 +167,7 @@
             <v-list-item>
               <Members
                 :namespace-urn="namespaceUrn"
+                :element-urn="urn"
                 @selectedMembers="selectedMembers = $event; element.members =
                   convertMembersFormat($event)"
               />

--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -220,6 +220,7 @@ import DataElementDetailView from '~/components/views/data-element-detail-view.v
 import GroupsRecordsDetailView from '~/components/views/groups-records-detail-view'
 import NamespaceDetailView from '~/components/views/namespace-detail-view.vue'
 import DefaultSnackbar from '~/components/snackbars/default-snackbar'
+
 export default {
   auth: false,
   components: {
@@ -262,7 +263,9 @@ export default {
   }),
   computed: {
     selected () {
-      if (!this.activeElements.length) { return undefined }
+      if (!this.activeElements.length) {
+        return undefined
+      }
       return this.selectedElement
     }
   },
@@ -347,7 +350,9 @@ export default {
           this.treeItems = []
           let namespaces
           namespaces = Array.from(res.READ)
-          if (res.ADMIN) { namespaces = Array.from(namespaces.concat(res.ADMIN, res.WRITE)) }
+          if (res.ADMIN) {
+            namespaces = Array.from(namespaces.concat(res.ADMIN, res.WRITE))
+          }
           for (const namespace of namespaces) {
             if (namespace.identification.status !== 'OUTDATED') {
               this.treeItems.push({
@@ -383,7 +388,7 @@ export default {
             } else {
               elementType = member.elementType.toUpperCase()
               urn = 'urn:' + element.urn.split(':')[1] + ':' +
-              member.elementType.toLowerCase() + ':' + member.identifier + ':' + member.revision
+                member.elementType.toLowerCase() + ':' + member.identifier + ':' + member.revision
             }
             if (member.status !== 'OUTDATED') {
               members.push({


### PR DESCRIPTION
**What's in the PR**
* Show current members in the dataElementGroup update dialog
* Do not allow adding OUTDATED elements as members

**How to test manually**
* Check if the described problem in [#56](https://github.com/mig-frankfurt/dataelementhub.gui/issues/56) is solved
