### PR TITLE
remove /auth from keycloak url

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -90,10 +90,10 @@ export default {
       keycloak: {
         scheme: 'oauth2',
         endpoints: {
-          authorization: process.env.KEYCLOAK_URL + '/auth/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/auth',
-          userInfo: process.env.KEYCLOAK_URL + '/auth/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/userinfo',
-          token: process.env.KEYCLOAK_URL + '/auth/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/token',
-          logout: process.env.KEYCLOAK_URL + '/auth/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/logout?redirect_uri=' + encodeURIComponent(process.env.BASE_URL)
+          authorization: process.env.KEYCLOAK_URL + '/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/auth',
+          userInfo: process.env.KEYCLOAK_URL + '/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/userinfo',
+          token: process.env.KEYCLOAK_URL + '/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/token',
+          logout: process.env.KEYCLOAK_URL + '/realms/' + process.env.KEYCLOAK_REALM + '/protocol/openid-connect/logout?redirect_uri=' + encodeURIComponent(process.env.BASE_URL)
         },
         token: {
           property: 'access_token',


### PR DESCRIPTION
**What's in the PR**
* removed `auth` suffix from keycloak url builder.

Recent versions of keycloak deploy their endpoint at `/` instead of the previously used `/auth` endpoint. Therefore this *should* be removed. If you're running an older version of Keycloak, just add `/auth` to the `KEYCLOAK_URL` env variable.