### PR TITLE
#92 - Set httpOnly to false for all auth cookies

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -91,7 +91,7 @@ export default {
     ],
     cookie: {
       options: {
-        httpOnly: true,
+        httpOnly: false,
         secure: true
       }
     },


### PR DESCRIPTION
**What's in the PR**
* Set httpOnly to false for all auth cookies
* close #92 

**How to test manually**
* Check if auth cookies can be used by javascript and the console warning is disappeared
