### PR TITLE
#112 - define env variables in docker compose instead of dockerfile

### DIFF
--- a/components/common/members.vue
+++ b/components/common/members.vue
@@ -89,8 +89,8 @@ export default {
         filteredMembers: []
       },
       ajax: {
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/',
-        elementUrl: process.env.mdrBackendUrl + '/v1/element/'
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/',
+        elementUrl: process.env.backendUrl + '/v1/element/'
       },
       namespaceMembers: [],
       selectedMembers: [],

--- a/components/dialogs/check-unreleased-members.vue
+++ b/components/dialogs/check-unreleased-members.vue
@@ -97,8 +97,8 @@ export default {
   data () {
     return {
       ajax: {
-        dataElementUrl: process.env.mdrBackendUrl + '/v1/element/',
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/'
+        dataElementUrl: process.env.backendUrl + '/v1/element/',
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/'
       },
       dialog: this.show,
       selectedItem: 1,

--- a/components/dialogs/data-element-dialog.vue
+++ b/components/dialogs/data-element-dialog.vue
@@ -375,9 +375,9 @@ export default {
   data () {
     return {
       ajax: {
-        dataElementUrl: process.env.mdrBackendUrl + '/v1/element/',
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/',
-        backendUrl: process.env.mdrBackendUrl
+        dataElementUrl: process.env.backendUrl + '/v1/element/',
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/',
+        backendUrl: process.env.backendUrl
       },
       dialog: false,
       dataElement: Object.assign({}, Common.defaultDataElement()),

--- a/components/dialogs/group-record-dialog.vue
+++ b/components/dialogs/group-record-dialog.vue
@@ -219,8 +219,8 @@ export default {
   data () {
     return {
       ajax: {
-        elementUrl: process.env.mdrBackendUrl + '/v1/element/',
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/'
+        elementUrl: process.env.backendUrl + '/v1/element/',
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/'
       },
       dialog: false,
       element: Object.assign({}, this.defaultElement()),

--- a/components/dialogs/namespace-dialog.vue
+++ b/components/dialogs/namespace-dialog.vue
@@ -191,7 +191,7 @@ export default {
   data () {
     return {
       ajax: {
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/'
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/'
       },
       dialog: false,
       namespace: Object.assign({}, Common.defaultNamespace()),

--- a/components/item/item-concept-association.vue
+++ b/components/item/item-concept-association.vue
@@ -58,7 +58,7 @@ export default {
   data () {
     return {
       ajax: {
-        sourceIdUrl: process.env.mdrBackendUrl + '/v1/source/'
+        sourceIdUrl: process.env.backendUrl + '/v1/source/'
       },
       sourceIds: [],
       currentConcept: this.conceptAssociation,

--- a/components/trees/namespace-tree.vue
+++ b/components/trees/namespace-tree.vue
@@ -36,8 +36,8 @@ export default {
   data () {
     return {
       ajax: {
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/',
-        elementUrl: process.env.mdrBackendUrl + '/v1/element/'
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/',
+        elementUrl: process.env.backendUrl + '/v1/element/'
       },
       treeItems: [],
       activeElements: [],

--- a/components/views/data-element-detail-view-child.vue
+++ b/components/views/data-element-detail-view-child.vue
@@ -98,7 +98,7 @@ export default {
   data () {
     return {
       ajax: {
-        dataElementUrl: process.env.mdrBackendUrl + '/v1/element/'
+        dataElementUrl: process.env.backendUrl + '/v1/element/'
       },
       dataElement: undefined,
       dialog: false

--- a/components/views/data-element-detail-view.vue
+++ b/components/views/data-element-detail-view.vue
@@ -243,7 +243,7 @@ export default {
   data () {
     return {
       ajax: {
-        dataElementUrl: process.env.mdrBackendUrl + '/v1/element/'
+        dataElementUrl: process.env.backendUrl + '/v1/element/'
       },
       detailViewDialog: {
         urn: '',

--- a/components/views/enumerated-value-domain-detail-view.vue
+++ b/components/views/enumerated-value-domain-detail-view.vue
@@ -196,7 +196,7 @@ export default {
   data () {
     return {
       ajax: {
-        valueDomainUrl: process.env.mdrBackendUrl + '/v1/element/'
+        valueDomainUrl: process.env.backendUrl + '/v1/element/'
       },
       detailViewDialog: {
         urn: '',

--- a/components/views/groups-records-detail-view.vue
+++ b/components/views/groups-records-detail-view.vue
@@ -229,7 +229,7 @@ export default {
   data () {
     return {
       ajax: {
-        elementUrl: process.env.mdrBackendUrl + '/v1/element/'
+        elementUrl: process.env.backendUrl + '/v1/element/'
       },
       detailViewDialog: {
         urn: '',

--- a/components/views/namespace-detail-view.vue
+++ b/components/views/namespace-detail-view.vue
@@ -121,7 +121,7 @@ export default {
   data () {
     return {
       ajax: {
-        namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/'
+        namespaceUrl: process.env.backendUrl + '/v1/namespaces/'
       },
       detailViewDialog: {
         urn: '',

--- a/components/views/permitted-value-detail-view.vue
+++ b/components/views/permitted-value-detail-view.vue
@@ -81,7 +81,7 @@ export default {
   data () {
     return {
       ajax: {
-        permittedValueUrl: process.env.mdrBackendUrl + '/v1/element/'
+        permittedValueUrl: process.env.backendUrl + '/v1/element/'
       },
       permittedValue: undefined,
       dialog: false

--- a/components/views/value-domain.vue
+++ b/components/views/value-domain.vue
@@ -51,7 +51,7 @@ export default {
   data () {
     return {
       ajax: {
-        dataElementUrl: process.env.mdrBackendUrl + '/v1/element/'
+        dataElementUrl: process.env.backendUrl + '/v1/element/'
       },
       valueDomain: undefined,
       selectedPermittedValueUrn: null,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,10 @@ ARG BACKEND_URL
 ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
-COPY package.json $DIR
-COPY package-lock.json $DIR
-RUN npm install
+RUN apt update
+RUN apt dist-upgrade -y
 COPY . $DIR
-RUN npm run build
+RUN npm install && npm run build
 EXPOSE 3000
 ENV NUXT_HOST=0.0.0.0
 ENV NUXT_PORT=3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0-alpine
+FROM node:16.17.0-alpine-slim
 ENV DIR=/usr/src/dehub-gui
 ARG KEYCLOAK_REALM
 ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}
@@ -13,7 +13,6 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
-RUN npm install -g npm@8.15.0
 RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
 RUN npm install
 RUN npm run build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0
+FROM node:16.17.0-alpine
 ENV DIR=/usr/src/dehub-gui
 ARG KEYCLOAK_REALM
 ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0-alpine-slim
+FROM node:16.17.0-buster-slim
 ENV DIR=/usr/src/dehub-gui
 ARG KEYCLOAK_REALM
 ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,6 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
-RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
 RUN npm install
 RUN npm run build
 EXPOSE 3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
-RUN apt update && apt install python3 -y
+RUN apt update && apt install -y python3 g++ build-essential
 RUN npm install -g npm@8.15.0
 RUN npm install
 RUN npm run build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:16.17.0-buster-slim
+ENV DIR=/usr/src/dehub-gui
+ARG KEYCLOAK_REALM
+ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}
+ARG KEYCLOAK_URL
+ENV KEYCLOAK_URL=${KEYCLOAK_URL}
+ARG BASE_URL
+ENV BASE_URL=${BASE_URL}
+ARG BACKEND_URL
+ENV BACKEND_URL=${BACKEND_URL}
+RUN mkdir -p $DIR
+WORKDIR $DIR
+RUN apt update
+RUN apt dist-upgrade -y
+COPY package*.json $DIR
+RUN npm install
+COPY .. $DIR
+RUN npm run build
+EXPOSE 3000
+ENV NUXT_HOST=0.0.0.0
+ENV NUXT_PORT=3000
+CMD [ "npm", "run", "start" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
-RUN apt update && apt install python -y
+RUN apt update && apt install python3 -y
 RUN npm install -g npm@8.15.0
 RUN npm install
 RUN npm run build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
+RUN npm install -g npm@8.15.0
 RUN npm install
 RUN npm run build
 EXPOSE 3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ ARG BACKEND_URL
 ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
-RUN apt update
-RUN apt dist-upgrade -y
 COPY package.json $DIR
 COPY package-lock.json $DIR
 RUN npm install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,10 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
-RUN npm install && npm run build
+RUN npm install -g npm@8.15.0
+RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
+RUN npm install
+RUN npm run build
 EXPOSE 3000
 ENV NUXT_HOST=0.0.0.0
 ENV NUXT_PORT=3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM node:16.17.0-buster-slim
 ENV DIR=/usr/src/dehub-gui
 ARG KEYCLOAK_REALM
 ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}
+ARG KEYCLOAK_CLIENT_ID
+ENV KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID}
 ARG KEYCLOAK_URL
 ENV KEYCLOAK_URL=${KEYCLOAK_URL}
 ARG BASE_URL
@@ -12,7 +14,8 @@ RUN mkdir -p $DIR
 WORKDIR $DIR
 RUN apt update
 RUN apt dist-upgrade -y
-COPY package*.json $DIR
+COPY package.json $DIR
+COPY package-lock.json $DIR
 RUN npm install
 COPY .. $DIR
 RUN npm run build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR $DIR
 COPY package.json $DIR
 COPY package-lock.json $DIR
 RUN npm install
-COPY .. $DIR
+COPY . $DIR
 RUN npm run build
 EXPOSE 3000
 ENV NUXT_HOST=0.0.0.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0-buster-slim
+FROM node:16.17.0
 ENV DIR=/usr/src/dehub-gui
 ARG KEYCLOAK_REALM
 ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ ARG BACKEND_URL
 ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
-RUN apt update
-RUN apt dist-upgrade -y
 COPY . $DIR
 RUN npm install && npm run build
 EXPOSE 3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ ENV BACKEND_URL=${BACKEND_URL}
 RUN mkdir -p $DIR
 WORKDIR $DIR
 COPY . $DIR
+RUN apt update && apt install python -y
 RUN npm install -g npm@8.15.0
 RUN npm install
 RUN npm run build

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,7 +3,7 @@ import colors from 'vuetify/es5/util/colors'
 export default {
   env: {
     baseUrl: process.env.BASE_URL || 'http://localhost:3000',
-    mdrBackendUrl: process.env.MDR_BACKEND_URL || 'http://localhost:8090',
+    backendUrl: process.env.BACKEND_URL || 'http://localhost:8090',
     snackbarTimeout: process.env.SNACKBAR_TIMEOUT || 2000
   },
   // Global page headers: https://go.nuxtjs.dev/config-head

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -5,7 +5,7 @@ export default {
   data () {
     return {
       ajax: {
-        versionUrl: process.env.mdrBackendUrl + '/v1/version'
+        versionUrl: process.env.backendUrl + '/v1/version'
       },
       backendData: undefined
     }

--- a/pages/all-elements.vue
+++ b/pages/all-elements.vue
@@ -235,8 +235,8 @@ export default {
     componentKey: 0,
     itemId: -1,
     ajax: {
-      namespaceUrl: process.env.mdrBackendUrl + '/v1/namespaces/',
-      elementUrl: process.env.mdrBackendUrl + '/v1/element/'
+      namespaceUrl: process.env.backendUrl + '/v1/namespaces/',
+      elementUrl: process.env.backendUrl + '/v1/element/'
     },
     dialog: {
       urn: '',

--- a/pages/namespaces.vue
+++ b/pages/namespaces.vue
@@ -284,7 +284,7 @@ export default {
   data () {
     return {
       ajax: {
-        namespaceUrl: process.env.mdrBackendUrl + '/namespaces/'
+        namespaceUrl: process.env.backendUrl + '/namespaces/'
       },
       global: {
         currentNamespace: undefined,

--- a/pages/tools/search.vue
+++ b/pages/tools/search.vue
@@ -143,7 +143,7 @@ export default {
   data () {
     return {
       ajax: {
-        searchUrl: process.env.mdrBackendUrl + '/v1/search'
+        searchUrl: process.env.backendUrl + '/v1/search'
       },
       elementTypes: Common.elementTypes(),
       elementStatuses: Common.elementStatuses(),


### PR DESCRIPTION
**What's in the PR**
* Dockerfile with all env variables as build args

**How to test manually**
* try to start [docker-compose](https://github.com/imi-frankfurt/dataelementhub.docker/blob/master/docker-compose.yaml). it should work with no problems. The used GUI_TAG should include commit `cabd3e0cbe6adcfb7982c0bd6c1ad58913bb83d8`
* close #112 
